### PR TITLE
Updated springframework maven repository

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -23,12 +23,12 @@
 		<repository>
 			<id>spring-milestone</id>
 			<name>Spring Framework Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>http://maven.springframework.pivotal.org/milestone</url>
 		</repository>
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Framework Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>http://maven.springframework.pivotal.org/release</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
springframework maven repository has been changed to maven.springframework.pivotal.org
